### PR TITLE
Fix threading bug in MotdEvent and UpdateNotifyEvent

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,7 @@ tasks {
     shadowJar {
         archiveBaseName.set(rootProject.name)
         archiveClassifier.set("")
-        destinationDirectory.set(file("/mnt/c/Users/Nicholas/Development/hytale-server/mods"))
+        destinationDirectory.set(layout.buildDirectory.dir("libs"))
 
         // Relocate dependencies to avoid conflicts
         relocate("com.google.gson", "com.nhulston.libs.gson")


### PR DESCRIPTION
## Summary
- Fix threading bug where `registerGlobal` handlers fire on Scheduler thread but access store components requiring WorldThread
- Wrap message sending in `world.schedule()` to ensure thread safety

## Problem
The `registerGlobal` handler can fire on any thread (e.g., Scheduler), but accessing store components requires the WorldThread. This caused:

```
IllegalStateException: Assert not in thread!
Thread[WorldThread - default] but was in Thread[Scheduler]
```

This cascaded into:
1. `Failed to add player ref of joining player to the world store`
2. `Store is currently processing! Ensure you aren't calling a store method from a system`
3. Default world removed exceptionally
4. All players unable to join ("no default world configured")

## Fix
Schedule the message sending on the player's world thread using `world.schedule()`.

## Files Changed
- `MotdEvent.java` - wrap message sending in `world.schedule()`
- `UpdateNotifyEvent.java` - wrap message sending in `world.schedule()`

## Test plan
- [x] Verify MOTD displays correctly on player join
- [x] Verify update notifications display for admins
- [x] Confirm no `IllegalStateException` threading errors in logs
- [ ] Stress test with many concurrent player joins